### PR TITLE
Fix broken blorb location code; update coverage scripts

### DIFF
--- a/build/profile.sh
+++ b/build/profile.sh
@@ -1,12 +1,16 @@
 #!/bin/zsh
+target=$(find target/debug/deps -regex ".*/mxyzptlk-[^.]*")
 
 cargo clean
-RUSTFLAGS="-C instrument-coverage" cargo test --tests
+RUSTFLAGS="-C instrument-coverage" cargo --quiet test --no-default-features --tests
 xcrun llvm-profdata merge -sparse default_*.profraw -o json5format.profdata
 xcrun llvm-cov show --use-color \
     --ignore-filename-regex='/.cargo/registry' \
     --instr-profile=json5format.profdata \
-    --object target/debug/deps/mxyzptlk-f9babb35b31800c3 \
+    --object ${target} \
     --show-instantiations \
     --show-line-counts-or-regions \
     --Xdemangler=rustfilt | less -R
+
+rm *.profraw
+rm json5format.profdata

--- a/build/report.sh
+++ b/build/report.sh
@@ -1,10 +1,13 @@
 #!/bin/zsh
+target=$(find target/debug/deps -regex ".*/mxyzptlk-[^.]*")
 
 cargo clean
-RUSTFLAGS="-C instrument-coverage" cargo --quiet test --tests
+RUSTFLAGS="-C instrument-coverage" cargo --quiet test --no-default-features --tests
 xcrun llvm-profdata merge -sparse default_*.profraw -o json5format.profdata
 xcrun llvm-cov report --use-color --ignore-filename-regex='/.cargo/registry' \
     --instr-profile=json5format.profdata \
-    --object target/debug/deps/mxyzptlk-f9babb35b31800c3 \
-    --show-instantiation-summary \
+    --object ${target} \
     --Xdemangler=rustfilt | less -R
+
+rm *.profraw
+rm json5format.profdata

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn main() {
     match File::open(filename) {
         Ok(mut f) => match Memory::try_from(&mut f) {
             Ok(memory) => {
-                let sound_manager = initialize_sound_engine(&name);
+                let sound_manager = initialize_sound_engine(&full_name);
                 let mut zmachine = ZMachine::new(memory, config, sound_manager, &name)
                     .expect("Error creating state");
 


### PR DESCRIPTION
Fixed the blorb file location to use the full path of the game file when searching, otherwise blorb files not in the current working directory aren't detected.

Added a `find` to the coverage scripts to (attempt to) find the instrumented binary.