### PR TITLE
Use italic styling, where available

### DIFF
--- a/src/zmachine/io/screen/curses/pancurses.rs
+++ b/src/zmachine/io/screen/curses/pancurses.rs
@@ -124,7 +124,7 @@ impl Terminal for PCTerminal {
             attributes |= A_BOLD;
         }
         if style.is_style(Style::Italic) {
-            attributes |= A_UNDERLINE;
+            attributes |= A_ITALIC;
         }
         if style.is_style(Style::Reverse) {
             attributes |= A_REVERSE;

--- a/src/zmachine/io/screen/curses/pancurses.rs
+++ b/src/zmachine/io/screen/curses/pancurses.rs
@@ -124,7 +124,11 @@ impl Terminal for PCTerminal {
             attributes |= A_BOLD;
         }
         if style.is_style(Style::Italic) {
-            attributes |= A_ITALIC;
+            if cfg!(target_os = "macos") {
+                attributes |= A_UNDERLINE;
+            } else {
+                attributes |= A_ITALIC;
+            }
         }
         if style.is_style(Style::Reverse) {
             attributes |= A_REVERSE;


### PR DESCRIPTION
MacOS doesn't seem to support italic text, but Windows and Linux (and Linux on Mac) do.